### PR TITLE
Improve error message when `R` is not installed

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,5 @@
 # Regexes for lines to exclude from consideration
 exclude_lines =
     print
+    except
+    raise

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -45,7 +45,6 @@ jobs:
           coverage run --source=rpy_symmetry -m pytest -v --durations 0
           coverage report
       - name: Upload coverage
-        if: matrix.test != 'minimal'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls --service=github

--- a/rpy_symmetry/rpy_symmetry.py
+++ b/rpy_symmetry/rpy_symmetry.py
@@ -58,14 +58,14 @@ def get_module(name: str = 'symmetry'):
 
 def _install_package_on_the_fly(package: str) -> None:
     from rpy2.robjects.vectors import StrVector
-    import rpy2.rinterface_lib.embedded.RRuntimeError
+    from rpy2.rinterface_lib.embedded import RRuntimeError
 
     utils = rpackages.importr('utils')
     packnames = (package,)
     utils.chooseCRANmirror(ind=1)
     try:
         utils.install_packages(StrVector(packnames))
-    except rpy2.rinterface_lib.embedded.RRuntimeError as e:
+    except RRuntimeError as e:
         raise RuntimeError(
             f'Cannot install {package} on the fly, please make sure that R is properly installed'
         ) from e

--- a/rpy_symmetry/rpy_symmetry.py
+++ b/rpy_symmetry/rpy_symmetry.py
@@ -67,8 +67,7 @@ def _install_package_on_the_fly(package: str) -> None:
         utils.install_packages(StrVector(packnames))
     except rpy2.rinterface_lib.embedded.RRuntimeError as e:
         raise RuntimeError(
-            f'Cannot install {package} on the fly, please make sure that R is '
-            f'properly installed'
+            f'Cannot install {package} on the fly, please make sure that R is properly installed'
         ) from e
 
 

--- a/rpy_symmetry/rpy_symmetry.py
+++ b/rpy_symmetry/rpy_symmetry.py
@@ -58,11 +58,15 @@ def get_module(name: str = 'symmetry'):
 
 def _install_package_on_the_fly(package: str) -> None:
     from rpy2.robjects.vectors import StrVector
+    import rpy2.rinterface_lib.embedded.RRuntimeError
 
     utils = rpackages.importr('utils')
     packnames = (package,)
     utils.chooseCRANmirror(ind=1)
-    utils.install_packages(StrVector(packnames))
+    try:
+        utils.install_packages(StrVector(packnames))
+    except rpy2.rinterface_lib.embedded.RRuntimeError as e:
+        raise RuntimeError(f'Cannot install {package} on the fly, please make sure that R is properly installed') from e
 
 
 def _float_or_str(x) -> ty.Union[str, float]:

--- a/rpy_symmetry/rpy_symmetry.py
+++ b/rpy_symmetry/rpy_symmetry.py
@@ -66,7 +66,10 @@ def _install_package_on_the_fly(package: str) -> None:
     try:
         utils.install_packages(StrVector(packnames))
     except rpy2.rinterface_lib.embedded.RRuntimeError as e:
-        raise RuntimeError(f'Cannot install {package} on the fly, please make sure that R is properly installed') from e
+        raise RuntimeError(
+            f'Cannot install {package} on the fly, please make sure that R is '
+            f'properly installed'
+        ) from e
 
 
 def _float_or_str(x) -> ty.Union[str, float]:


### PR DESCRIPTION
If R is not installed, a rather cryptic error message is ported via `rpy2`, in this PR, we add extra information at the place the error will be raised.