### PR TITLE
Remove numpy and rpy2 from test-requirements

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -36,10 +36,9 @@ jobs:
           mamba-version: '*'
       - name: install
         run: |
-          conda install -c conda-forge r-base rpy2  -q
-          pip install -r .test_requirements.txt
+          conda install -c conda-forge r-base  -q
           pip install -e ../rpy_symmetry
-          pip install nbmake ipython tqdm matplotlib
+          pip install -r .test_requirements.txt
       - name: Run the tests
         run:
           |

--- a/.test_requirements.txt
+++ b/.test_requirements.txt
@@ -1,5 +1,3 @@
 coverage
 coveralls
-numpy
 pytest
-rpy2

--- a/.test_requirements.txt
+++ b/.test_requirements.txt
@@ -1,3 +1,7 @@
 coverage
 coveralls
+ipython
+matplotlib
+nbmake
 pytest
+tqdm


### PR DESCRIPTION
Should be installed as they are listed as dependencies in the toml file