### PR TITLE
Cache import routine

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,6 +1,12 @@
 import unittest
 
 
+def test_install_on_fly():
+    import rpy_symmetry as rsym
+
+    rsym.get_module('no_such_module')
+
+
 def test_minimal():
     import rpy_symmetry as rsym
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -8,6 +8,18 @@ def test_minimal():
     assert pval
 
 
+def test_wo_cache():
+    import rpy_symmetry as rsym
+
+    assert rsym.rpy_symmetry._imported_package
+    rsym.rpy_symmetry.ALLOW_CACHING = False
+    rsym.rpy_symmetry._imported_package = {}
+    pval = rsym.p_symmetry([1, 2, 3])
+    
+    assert pval
+    assert rsym.rpy_symmetry._imported_package == {}
+
+
 class RaiseMod(unittest.TestCase):
     def test_raises(self):
         import rpy_symmetry as rsym

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -15,7 +15,7 @@ def test_wo_cache():
     rsym.rpy_symmetry.ALLOW_CACHING = False
     rsym.rpy_symmetry._imported_package = {}
     pval = rsym.p_symmetry([1, 2, 3])
-    
+
     assert pval
     assert rsym.rpy_symmetry._imported_package == {}
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -4,7 +4,7 @@ import unittest
 def test_install_on_fly():
     import rpy_symmetry as rsym
 
-    rsym.get_module('no_such_module')
+    rsym.get_module('symmetry')
 
 
 def test_minimal():


### PR DESCRIPTION
About 50% of the current execution time is lost on (re)importing r-modules. To prevent this, allow very simple caching of the module itself in a global dictionary.

## Performance
In the simple example below, evaluating a random array of 200 samples speeds up by roughly a factor of 2:
![image](https://github.com/JoranAngevaare/rpy_symmetry/assets/22295914/7ad41bcf-ff41-40b0-9dcb-7ca8d81380fc)
